### PR TITLE
Fix strto{u,}{l,ll}("0").

### DIFF
--- a/functions/_PDCLIB/_PDCLIB_strtox_prelim.c
+++ b/functions/_PDCLIB/_PDCLIB_strtox_prelim.c
@@ -38,6 +38,10 @@ const char * _PDCLIB_strtox_prelim( const char * p, char * sign, int * base )
         else if ( *base == 0 )
         {
             *base = 8;
+            /* back up one digit, so that the string which is just a
+               plain zero is decoded correctly (and endptr is
+               appropriately recorded) */
+            p--;
         }
         else
         {
@@ -70,7 +74,7 @@ int main( void )
     TESTCASE( base == 10 );
     base = 0;
     sign = '\0';
-    TESTCASE( _PDCLIB_strtox_prelim( test2, &sign, &base ) == &test2[3] );
+    TESTCASE( _PDCLIB_strtox_prelim( test2, &sign, &base ) == &test2[2] );
     TESTCASE( sign == '+' );
     TESTCASE( base == 8 );
     base = 0;

--- a/functions/stdlib/strtol.c
+++ b/functions/stdlib/strtol.c
@@ -65,6 +65,10 @@ int main( void )
     TESTCASE( endptr == tricky + 2 );
     /* errno should still be 0 */
     TESTCASE( errno == 0 );
+    /* correctly decoding zero */
+    TESTCASE( strtol( "0", &endptr, 0 ) == 0 );
+    TESTCASE( *endptr == '\0' );
+    TESTCASE( errno == 0 );
     /* overflowing subject sequence must still return proper endptr */
     TESTCASE( strtol( overflow, &endptr, 36 ) == LONG_MIN );
     TESTCASE( errno == ERANGE );

--- a/functions/stdlib/strtoll.c
+++ b/functions/stdlib/strtoll.c
@@ -65,6 +65,10 @@ int main( void )
     TESTCASE( endptr == tricky + 2 );
     /* errno should still be 0 */
     TESTCASE( errno == 0 );
+    /* correctly decoding zero */
+    TESTCASE( strtoll( "0", &endptr, 0 ) == 0 );
+    TESTCASE( *endptr == '\0' );
+    TESTCASE( errno == 0 );
     /* overflowing subject sequence must still return proper endptr */
     TESTCASE( strtoll( overflow, &endptr, 36 ) == LLONG_MIN );
     TESTCASE( errno == ERANGE );

--- a/functions/stdlib/strtoul.c
+++ b/functions/stdlib/strtoul.c
@@ -58,6 +58,10 @@ int main( void )
     TESTCASE( endptr == tricky + 2 );
     /* errno should still be 0 */
     TESTCASE( errno == 0 );
+    /* correctly decoding zero */
+    TESTCASE( strtoul( "0", &endptr, 0 ) == 0 );
+    TESTCASE( *endptr == '\0' );
+    TESTCASE( errno == 0 );
     /* overflowing subject sequence must still return proper endptr */
     TESTCASE( strtoul( overflow, &endptr, 36 ) == ULONG_MAX );
     TESTCASE( errno == ERANGE );

--- a/functions/stdlib/strtoull.c
+++ b/functions/stdlib/strtoull.c
@@ -58,6 +58,10 @@ int main( void )
     TESTCASE( endptr == tricky + 2 );
     /* errno should still be 0 */
     TESTCASE( errno == 0 );
+    /* correctly decoding zero */
+    TESTCASE( strtoull( "0", &endptr, 0 ) == 0 );
+    TESTCASE( *endptr == '\0' );
+    TESTCASE( errno == 0 );
     /* overflowing subject sequence must still return proper endptr */
     TESTCASE( strtoull( overflow, &endptr, 36 ) == ULLONG_MAX );
     TESTCASE( errno == ERANGE );


### PR DESCRIPTION
Calling `strto{u,}{l,ll}("0")` sets `endptr` incorrectly. See the tests and the fix in the suggested commit.

Thanks for PDClib, it's a great project.