### PR TITLE
Avoid C++ keywords

### DIFF
--- a/functions/stdio/rename.c
+++ b/functions/stdio/rename.c
@@ -14,19 +14,19 @@
 
 extern struct _PDCLIB_file_t * _PDCLIB_filelist;
 
-int rename( const char * old, const char * new )
+int rename( const char * oldpath, const char * newpath )
 {
     struct _PDCLIB_file_t * current = _PDCLIB_filelist;
     while ( current != NULL )
     {
-        if ( ( current->filename != NULL ) && ( strcmp( current->filename, old ) == 0 ) )
+        if ( ( current->filename != NULL ) && ( strcmp( current->filename, oldpath ) == 0 ) )
         {
             /* File of that name currently open. Do not rename. */
             return EOF;
         }
         current = current->next;
     }
-    return _PDCLIB_rename( old, new );
+    return _PDCLIB_rename( oldpath, newpath );
 }
 
 #endif

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -64,7 +64,7 @@ int remove( const char * filename );
    If there already is a file with the new filename, behaviour is defined by
    the glue code (see functions/_PDCLIB/rename.c).
 */
-int rename( const char * old, const char * new );
+int rename( const char * oldpath, const char * newpath );
 
 /* Open a temporary file with mode "wb+", i.e. binary-update. Remove the file
    automatically if it is closed or the program exits normally (by returning

--- a/platform/example/functions/_PDCLIB/_PDCLIB_rename.c
+++ b/platform/example/functions/_PDCLIB/_PDCLIB_rename.c
@@ -17,18 +17,18 @@
 #include </usr/include/errno.h>
 
 extern int unlink( const char * pathname );
-extern int link( const char * old, const char * new );
+extern int link( const char * oldpath, const char * newpath );
 
-int _PDCLIB_rename( const char * old, const char * new )
+int _PDCLIB_rename( const char * oldpath, const char * newpath )
 {
     /* Note that the behaviour if new file exists is implementation-defined.
        There is nothing wrong with either overwriting it or failing the
        operation, but you might want to document whichever you chose.
        This example fails if new file exists.
     */
-    if ( link( old, new ) == 0 )
+    if ( link( oldpath, newpath ) == 0 )
     {
-        if ( unlink( old ) == EOF )
+        if ( unlink( oldpath ) == EOF )
         {
             /* The 1:1 mapping in _PDCLIB_config.h ensures this works. */
             _PDCLIB_errno = errno;


### PR DESCRIPTION
During compilation of a C++ project I noticed that the keyword `new` was used in a few places throughout PDClib. This resulted in various errors which could easily be avoided.

I read Notes.txt and understand that this change might be non-conventional but I figure that the goal justifies the means.