### PR TITLE
Fix PDCLib fwrite segfault

### DIFF
--- a/functions/stdio/fwrite.c
+++ b/functions/stdio/fwrite.c
@@ -48,6 +48,7 @@ size_t fwrite( const void * _PDCLIB_restrict ptr, size_t size, size_t nmemb, str
                     _PDCLIB_UNLOCK( stream->mtx );
                     return nmemb_i;
                 }
+                offset = 0;
                 /* lineend = false; */
             }
         }


### PR DESCRIPTION
Not resetting last seen '\n' offset after flushing the buffer
(which resets the buffer index to 0) can lead to a situation where
that offset has a higher value the the current buffer index,
overflowing (unsigned) stream->bufidx = bufidx - offset
and then doing a  memmove of a gigantic size.