### PR TITLE
Optimise the count of division/remainder operations

### DIFF
--- a/functions/_PDCLIB/_PDCLIB_print.c
+++ b/functions/_PDCLIB/_PDCLIB_print.c
@@ -185,6 +185,7 @@ static void intformat( intmax_t value, struct _PDCLIB_status_t * status )
                already so it will be taken into account when the deepestmost recursion \
                does the prefix / padding stuff. \
             */ \
+            int digit = value % status->base; \
             ++(status->current); \
             if ( ( value / status->base ) != 0 ) \
             { \
@@ -201,22 +202,19 @@ static void intformat( intmax_t value, struct _PDCLIB_status_t * status )
                 intformat( value, status ); \
             } \
             /* Recursion tail - print the current digit. */ \
+            if ( digit < 0 ) \
             { \
-                int digit = value % status->base; \
-                if ( digit < 0 ) \
-                { \
-                    digit *= -1; \
-                } \
-                if ( status->flags & E_lower ) \
-                { \
-                    /* Lowercase letters. Same array used for strto...(). */ \
-                    PUT( _PDCLIB_digits[ digit ] ); \
-                } \
-                else \
-                { \
-                    /* Uppercase letters. Array only used here, only 0-F. */ \
-                    PUT( _PDCLIB_Xdigits[ digit ] ); \
-                } \
+                digit *= -1; \
+            } \
+            if ( status->flags & E_lower ) \
+            { \
+                /* Lowercase letters. Same array used for strto...(). */ \
+                PUT( _PDCLIB_digits[ digit ] ); \
+            } \
+            else \
+            { \
+                /* Uppercase letters. Array only used here, only 0-F. */ \
+                PUT( _PDCLIB_Xdigits[ digit ] ); \
             } \
         } \
     } while ( 0 )


### PR DESCRIPTION
Some compilers can't do the proper optimization of the code, which this PR modifies.
At least GCC and Clang produces `div_mod` operation twice - for `value / status->base` and `digit = value % status->base`.
In order to help compiler generate better code we need keep `div` and `mod` code sections close to each other.

Poor output example: https://godbolt.org/z/cEMx41
Better output example: https://godbolt.org/z/o3fc13

Of course we don't need to do the optimization instead of the compilers but maybe they thinks that `status->base` can be modified in between `div` and `mod` sections.
Please take it into account.