### PR TITLE
`strtod`: Add basic base-10 parsing

### DIFF
--- a/functions/_PDCLIB/_PDCLIB_strtod_main.c
+++ b/functions/_PDCLIB/_PDCLIB_strtod_main.c
@@ -10,6 +10,7 @@
 #ifndef REGTEST
 
 #include <ctype.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -40,6 +41,11 @@ static double _PDCLIB_strtod_main( const char * nptr, char ** endptr )
     {
         case 10:
             {
+                uint64_t significand = 0;
+                int exponent = 0;
+                int exponent_shift = 0;
+                int exponent_sign = 1;
+
                 /* Infinity */
                 if ( tolower( p[0] ) == 'i' && tolower( p[1] ) == 'n' && tolower( p[2] ) == 'f' )
                 {
@@ -96,9 +102,107 @@ static double _PDCLIB_strtod_main( const char * nptr, char ** endptr )
                     return value;
                 }
 
-                /* TODO: base-10 conversion */
+                /* TODO: out-of-range error handling */
+                for ( const char * it = p; it != dec_end; ++it )
+                {
+                    significand = significand * 10 + (*it - '0');
+                    if ( significand >= ((UINT64_MAX - 9) / 10) )
+                    {
+                        /* skip non-significant significand digits
+                        ** (increase exponent by d to shift decimal left) */
+                        exponent_shift += (int)( dec_end - it );
+                        break;
+                    }
+                }
 
-                return 0.0;
+                /* if decimal point is present */
+                if ( frac_end != dec_end )
+                {
+                    /* copy digits from after decimal to significand
+                    ** (decrease exponent by d to shift decimal right) */
+                    for ( const char * it = dec_end + 1; it != frac_end; ++it )
+                    {
+                        if ( significand < ((UINT64_MAX - 9) / 10) )
+                        {
+                            significand = significand * 10 + (*it - '0');
+                            --exponent_shift;
+                        }
+                    }
+                }
+
+                /* if exponent is present */
+                if ( exp_end != frac_end )
+                {
+                    const char * it = frac_end + 1;
+                    if (*it == '-')
+                    {
+                        exponent_sign = -1;
+                        ++it;
+                    }
+                    else if (*it == '+')
+                    {
+                        ++it;
+                    }
+                    for ( ; it != exp_end; ++it )
+                    {
+                        exponent = exponent < 10000 ? (exponent * 10 + (*it - '0')) : 10000;
+                    }
+                }
+
+                if ( endptr != NULL )
+                {
+                    *endptr = (char *)exp_end;
+                }
+
+                if ( significand == 0 )
+                {
+                    return sign < 0 ? -0.0 : +0.0;
+                }
+
+                exponent = (exponent * exponent_sign) + exponent_shift;
+                while ( exponent > 0 && significand < (UINT64_MAX / 10) )
+                {
+                    significand *= 10;
+                    --exponent;
+                }
+                while ( exponent < 0 && (significand % 10) == 0 )
+                {
+                    significand /= 10;
+                    ++exponent;
+                }
+
+                if ( exponent == 0 )
+                {
+                    value = significand;
+                }
+                else
+                {
+                    long double r = (long double)significand;
+                    if ( exponent > 0 )
+                    {
+                        while ( exponent >= 100  ) { exponent -= 100; r *= 1.0e+100L; }
+                        while ( exponent >= 10   ) { exponent -= 10;  r *= 1.0e+10L;  }
+                        while ( exponent >= 1    ) { exponent -= 1;   r *= 1.0e+01L;  }
+                    }
+                    else
+                    {
+                        while ( exponent <= -100 ) { exponent += 100; r *= 1.0e-100L; }
+                        while ( exponent <= -10  ) { exponent += 10;  r *= 1.0e-10L;  }
+                        while ( exponent <= -1   ) { exponent += 1;   r *= 1.0e-01L;  }
+                    }
+                    if ( r > +1.7976931348623157081452742373e+308L )
+                    {
+                        value = 1.0e308*10.0; /* INFINITY */
+                    }
+                    else
+                    {
+                        value = (double)r;
+                    }
+                }
+
+                if ( sign == '-' ) value = -value;
+
+                return value;
             }
         case 16:
             {
@@ -142,7 +246,10 @@ int main( void )
         "0xa.bcdp+6", "+0x000.001p-1", "-0x12p4", "0x.123p-6", "0x123.p-5",
         ".123e-4", "123.e-4",
         ".e", ".", "",
-        "foo"
+        "foo",
+        "0.5", "-0.5",
+        "10", "20",
+        "10.5"
     };
     double expected_doubles[] =
     {
@@ -154,7 +261,10 @@ int main( void )
         0x1.579ap+9, 0x1p-13, -0x1.2p+8, 0x1.23p-10, 0x1.23p+3,
         0x1.9cb8320b1507p-17, 0x1.930be0ded288dp-7,
         0x0p+0, 0x0p+0, 0x0p+0,
-        0.0
+        0.0,
+        0.5, -0.5,
+        10, 20,
+        10.5,
     };
     ptrdiff_t expected_endptr[] =
     {
@@ -166,7 +276,10 @@ int main( void )
         10, 13, 7, 9, 9,
         7, 7,
         0, 0, 0,
-        0
+        0,
+        3, 4,
+        2, 2,
+        4,
     };
     char const * nan_tests[] =
     {

--- a/functions/_PDCLIB/_PDCLIB_strtox_prelim.c
+++ b/functions/_PDCLIB/_PDCLIB_strtox_prelim.c
@@ -5,6 +5,7 @@
 */
 
 #include <ctype.h>
+#include <locale.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -12,6 +13,14 @@
 
 const char * _PDCLIB_strtox_prelim( const char * p, char * sign, int * base )
 {
+    char decimal_point = '.';
+    struct lconv * lconv;
+
+    if ( ( lconv = localeconv() ) != NULL )
+    {
+        decimal_point = *lconv->decimal_point;
+    }
+
     /* skipping leading whitespace */
     while ( isspace( *p ) )
     {
@@ -50,7 +59,7 @@ const char * _PDCLIB_strtox_prelim( const char * p, char * sign, int * base )
         }
         else if ( *base == 0 )
         {
-            *base = 8;
+            *base = *p == decimal_point ? 10 : 8;
             /* back up one digit, so that a plain zero is decoded correctly
                (and endptr is set correctly as well).
                (2019-01-15, Giovanni Mascellani)


### PR DESCRIPTION
Loosely based on the SQLite implementation from:

https://github.com/sqlite/sqlite/blob/6161cdd446eec170f7c0edf58d0d72a2cd3c5f85/src/util.c#L478

Not implemented:

1. Base 16 parsing.
2. Setting `errno` to ERANGE on overflow / underflow.

SQLite [is Public Domain](https://www.sqlite.org/copyright.html).

/cc @JayFoxRox