### PR TITLE
Typo in _PDCLIB_stdinit.c 

### DIFF
--- a/platform/example/functions/_PDCLIB/_PDCLIB_stdinit.c
+++ b/platform/example/functions/_PDCLIB/_PDCLIB_stdinit.c
@@ -519,7 +519,7 @@ struct _PDCLIB_lc_time_t _PDCLIB_lc_time_C =
         ( char * )"Aug",
         ( char * )"Sep",
         ( char * )"Oct",
-        ( char * )"Now",
+        ( char * )"Nov",
         ( char * )"Dec"
     },
     /* _PDCLIB_month_name_full */


### PR DESCRIPTION
typo in `_PDCLIB_lc_time_t` definitions of `_PDCLIB_month_name_abbr`. Corrected `"Now"` to `"Nov"` for November.

It's a small issue, but I am concerned that it could break projects or cause headaches e.g when writing tests.