### PR TITLE
Refactor _PDCLIB_strtox_main to reduce parameters to 5

### DIFF
--- a/functions/_PDCLIB/_PDCLIB_strtox_main.c
+++ b/functions/_PDCLIB/_PDCLIB_strtox_main.c
@@ -11,11 +11,13 @@
 
 #ifndef REGTEST
 
-_PDCLIB_uintmax_t _PDCLIB_strtox_main( const char ** p, unsigned int base, uintmax_t error, uintmax_t limval, int limdigit, char * sign )
+_PDCLIB_uintmax_t _PDCLIB_strtox_main( const char ** p, unsigned int base, uintmax_t error, uintmax_t limit, char * sign )
 {
     _PDCLIB_uintmax_t rc = 0;
     int digit = -1;
     const char * x;
+    _PDCLIB_uintmax_t limval = limit / base;
+    int limdigit = limit % base;
 
     while ( ( x = (const char *)memchr( _PDCLIB_digits, tolower( (unsigned char)**p ), base ) ) != NULL )
     {
@@ -70,17 +72,17 @@ int main( void )
     /* basic functionality */
     p = test;
     errno = 0;
-    TESTCASE( _PDCLIB_strtox_main( &p, 10u, ( uintmax_t )999, ( uintmax_t )12, 3, &sign ) == 123 );
+    TESTCASE( _PDCLIB_strtox_main( &p, 10u, ( uintmax_t )999, ( uintmax_t )999, &sign ) == 123 );
     TESTCASE( errno == 0 );
     TESTCASE( p == &test[3] );
     /* proper functioning to smaller base */
     p = test;
-    TESTCASE( _PDCLIB_strtox_main( &p, 8u, ( uintmax_t )999, ( uintmax_t )12, 3, &sign ) == 0123 );
+    TESTCASE( _PDCLIB_strtox_main( &p, 8u, ( uintmax_t )999, ( uintmax_t )999, &sign ) == 0123 );
     TESTCASE( errno == 0 );
     TESTCASE( p == &test[3] );
     /* overflowing subject sequence must still return proper endptr */
     p = test;
-    TESTCASE( _PDCLIB_strtox_main( &p, 4u, ( uintmax_t )999, ( uintmax_t )1, 2, &sign ) == 999 );
+    TESTCASE( _PDCLIB_strtox_main( &p, 4u, ( uintmax_t )999, ( uintmax_t )6, &sign ) == 999 );
     TESTCASE( errno == ERANGE );
     TESTCASE( p == &test[3] );
     TESTCASE( sign == '+' );
@@ -88,7 +90,7 @@ int main( void )
     errno = 0;
     p = fail;
     sign = '-';
-    TESTCASE( _PDCLIB_strtox_main( &p, 10u, ( uintmax_t )999, ( uintmax_t )99, 8, &sign ) == 0 );
+    TESTCASE( _PDCLIB_strtox_main( &p, 10u, ( uintmax_t )999, ( uintmax_t )999, &sign ) == 0 );
     TESTCASE( p == NULL );
 #endif
     return TEST_RESULTS;

--- a/functions/inttypes/strtoimax.c
+++ b/functions/inttypes/strtoimax.c
@@ -24,11 +24,11 @@ intmax_t strtoimax( const char * _PDCLIB_restrict nptr, char ** _PDCLIB_restrict
 
     if ( sign == '+' )
     {
-        rc = ( intmax_t )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )INTMAX_MAX, ( uintmax_t )( INTMAX_MAX / base ), ( int )( INTMAX_MAX % base ), &sign );
+        rc = ( intmax_t )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )INTMAX_MAX, ( uintmax_t )INTMAX_MAX, &sign );
     }
     else
     {
-        rc = ( intmax_t )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )INTMAX_MIN, ( uintmax_t )( INTMAX_MIN / -base ), ( int )( -( INTMAX_MIN % base ) ), &sign );
+        rc = ( intmax_t )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )INTMAX_MIN, ( ( uintmax_t )INTMAX_MAX + 1 ), &sign );
     }
 
     if ( endptr != NULL )

--- a/functions/inttypes/strtoumax.c
+++ b/functions/inttypes/strtoumax.c
@@ -22,7 +22,7 @@ uintmax_t strtoumax( const char * _PDCLIB_restrict nptr, char ** _PDCLIB_restric
         return 0;
     }
 
-    rc = _PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )UINTMAX_MAX, ( uintmax_t )( UINTMAX_MAX / base ), ( int )( UINTMAX_MAX % base ), &sign );
+    rc = _PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )UINTMAX_MAX, ( uintmax_t )UINTMAX_MAX, &sign );
 
     if ( endptr != NULL )
     {

--- a/functions/stdlib/strtol.c
+++ b/functions/stdlib/strtol.c
@@ -24,11 +24,11 @@ long int strtol( const char * s, char ** endptr, int base )
 
     if ( sign == '+' )
     {
-        rc = ( long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )LONG_MAX, ( uintmax_t )( LONG_MAX / base ), ( int )( LONG_MAX % base ), &sign );
+        rc = ( long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )LONG_MAX, ( uintmax_t )LONG_MAX, &sign );
     }
     else
     {
-        rc = ( long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )LONG_MIN, ( uintmax_t )( LONG_MIN / -base ), ( int )( -( LONG_MIN % base ) ), &sign );
+        rc = ( long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )( unsigned long )LONG_MIN, ( ( uintmax_t )LONG_MAX + 1 ), &sign );
     }
 
     if ( endptr != NULL )

--- a/functions/stdlib/strtoll.c
+++ b/functions/stdlib/strtoll.c
@@ -24,11 +24,11 @@ long long int strtoll( const char * s, char ** endptr, int base )
 
     if ( sign == '+' )
     {
-        rc = ( long long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )LLONG_MAX, ( uintmax_t )( LLONG_MAX / base ), ( int )( LLONG_MAX % base ), &sign );
+        rc = ( long long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )LLONG_MAX, ( uintmax_t )LLONG_MAX, &sign );
     }
     else
     {
-        rc = ( long long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )LLONG_MIN, ( uintmax_t )( LLONG_MIN / -base ), ( int )( -( LLONG_MIN % base ) ), &sign );
+        rc = ( long long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )( unsigned long long )LLONG_MIN, ( ( uintmax_t )LLONG_MAX + 1 ), &sign );
     }
 
     if ( endptr != NULL )

--- a/functions/stdlib/strtoul.c
+++ b/functions/stdlib/strtoul.c
@@ -22,7 +22,7 @@ unsigned long int strtoul( const char * s, char ** endptr, int base )
         return 0;
     }
 
-    rc = ( unsigned long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )ULONG_MAX, ( uintmax_t )( ULONG_MAX / base ), ( int )( ULONG_MAX % base ), &sign );
+    rc = ( unsigned long int )_PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )ULONG_MAX, ( uintmax_t )ULONG_MAX, &sign );
 
     if ( endptr != NULL )
     {

--- a/functions/stdlib/strtoull.c
+++ b/functions/stdlib/strtoull.c
@@ -22,7 +22,7 @@ unsigned long long int strtoull( const char * s, char ** endptr, int base )
         return 0;
     }
 
-    rc = _PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )ULLONG_MAX, ( uintmax_t )( ULLONG_MAX / base ), ( int )( ULLONG_MAX % base ), &sign );
+    rc = _PDCLIB_strtox_main( &p, ( unsigned )base, ( uintmax_t )ULLONG_MAX, ( uintmax_t )ULLONG_MAX, &sign );
 
     if ( endptr != NULL )
     {

--- a/include/pdclib/_PDCLIB_internal.h
+++ b/include/pdclib/_PDCLIB_internal.h
@@ -382,7 +382,7 @@ _PDCLIB_LOCAL _PDCLIB_intmax_t _PDCLIB_atomax( const char * s );
 
 /* Two helper functions used by strtol(), strtoul() and long long variants.   */
 _PDCLIB_LOCAL const char * _PDCLIB_strtox_prelim( const char * p, char * sign, int * base );
-_PDCLIB_LOCAL _PDCLIB_uintmax_t _PDCLIB_strtox_main( const char ** p, unsigned int base, _PDCLIB_uintmax_t error, _PDCLIB_uintmax_t limval, int limdigit, char * sign );
+_PDCLIB_LOCAL _PDCLIB_uintmax_t _PDCLIB_strtox_main( const char ** p, unsigned int base, _PDCLIB_uintmax_t error, _PDCLIB_uintmax_t limit, char * sign );
 
 /* Helper function used by strtof(), strtod(), and strtold().                 */
 _PDCLIB_LOCAL int _PDCLIB_strtod_prelim( const char * p, char * sign, char ** endptr );


### PR DESCRIPTION
I am currently porting several functions to the eBPF architecture, which supports a maximum of only 5 arguments per function call. To meet this constraint, I have refactored the internal _PDCLIB_strtox_main function to reduce its parameter count from 6 to 5 by consolidating the overflow boundary arguments into a single limit parameter.