### PR TITLE
add HUGE_VAL(f/l)

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -17,9 +17,9 @@ extern "C" {
 typedef float float_t;
 typedef double double_t;
 
-#define HUGE_VALF _PDCLIB_HUGE_VALF;
-#define HUGE_VAL _PDCLIB_HUGE_VAL;
-#define HUGE_VALL _PDCLIB_HUGE_VALL;
+#define HUGE_VALF INFINITY
+#define HUGE_VAL ((double)INFINITY)
+#define HUGE_VALL ((long double)INFINITY)
 
 #define INFINITY (_PDCLIB_FLT_MAX * 2)
 #define NAN ( -(0.0f / 0.0f) )


### PR DESCRIPTION
closes https://github.com/DevSolar/pdclib/issues/29


https://www.open-std.org/jtc1/sc22/wg14/www/projects#9899

>HUGE_VAL, HUGE_VALF, and HUGE_VALL can be positive infinities in an implementation that supports infinities.

>The Standard C macro HUGE_VAL and its float and long double analogs, HUGE_VALF and
HUGE_VALL, expand to expressions whose values are positive infinities

I don't think the pdclib abstraction is needed since infinity is defined just after anyway. Need this for lua.